### PR TITLE
Fix run TF model in original framework when config is used

### DIFF
--- a/src/benchmark/config_parser.py
+++ b/src/benchmark/config_parser.py
@@ -420,7 +420,6 @@ class IntelCaffeParameters(ParametersMethods):
 
 
 class TensorFlowParameters(ParametersMethods):
-    @staticmethod
     def __init__(self, channel_swap, mean, input_scale, input_shape, input_name, output_names, thread_count,
                  inter_op_parallelism_threads, intra_op_parallelism_threads, kmp_affinity):
         self.channel_swap = None


### PR DESCRIPTION
was:
```
$ python3 src/benchmark/inference_benchmark.py -r results.csv --executor_type host_machine -c my_test_config.xml
[ ERROR ] _init_() missing 1 required positional argument: 'self'
```
now:
```
python3 src/benchmark/inference_benchmark.py -r results.csv --executor_type host_machine -c my_test_config.xml
[ INFO ] Create result table with name: results.csv
[ INFO ] Start 1 inference tests

[ INFO ] Start inference test on model : resnet-50-tf
[ INFO ] Command line is : python3 /home/zmas/code/dl-benchmark/src/inference/inference_tensorflow.py -m /home/zmas/code/dl-benchmark/working_dir/public/resnet-50-tf/resnet_v1-50.pb -i /mnt/c/Users/z.maslova/Desktop/20210617_125857.jpg -b 1 -d CPU -ni 1000 --input_shape 224 224 3 --raw_output true
...
```