### PR TITLE
Add ability to launch onnx models without IR via benchmark_app

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 max-line-length = 120
 show_source = True
 exclude = venv
+          src/onnxruntime_benchmark/thirdparty
 docstring-convention = google
 enable-extensions=G
 per-file-ignores =

--- a/src/benchmark/frameworks/config_parser/framework_parameters_parser.py
+++ b/src/benchmark/frameworks/config_parser/framework_parameters_parser.py
@@ -15,3 +15,18 @@ class FrameworkParameters:
             if not self._int_value_is_correct(i):
                 return False
         return True
+
+    def _mean_is_correct(self, mean):
+        mean_check = mean.replace('[', '').replace(']', '').replace(',', ' ').split()
+        if len(mean_check) != 3:
+            return False
+        for i in mean_check:
+            if not self._float_value_is_correct(i):
+                return False
+        return True
+
+    @staticmethod
+    def _channel_swap_is_correct(channel_swap):
+        set_check = {'0', '1', '2'}
+        set_in = set(channel_swap.split())
+        return set_in == set_check

--- a/src/benchmark/frameworks/intel_caffe/intel_caffe_parameters_parser.py
+++ b/src/benchmark/frameworks/intel_caffe/intel_caffe_parameters_parser.py
@@ -63,18 +63,3 @@ class IntelCaffeParameters(FrameworkParameters):
                 raise ValueError('Threads count can only take integer value')
         if self._parameter_not_is_none(kmp_affinity):
             self.kmp_affinity = kmp_affinity
-
-    @staticmethod
-    def _channel_swap_is_correct(channel_swap):
-        set_check = {'0', '1', '2'}
-        set_in = set(channel_swap.split())
-        return set_in == set_check
-
-    def _mean_is_correct(self, mean):
-        mean_check = mean.split()
-        if len(mean_check) != 3:
-            return False
-        for i in mean_check:
-            if not self._float_value_is_correct(i):
-                return False
-        return True

--- a/src/benchmark/frameworks/intel_caffe/intel_caffe_process.py
+++ b/src/benchmark/frameworks/intel_caffe/intel_caffe_process.py
@@ -35,14 +35,11 @@ class IntelCaffeProcess(ProcessHandler):
 
         common_params = f'-m {model_prototxt} -w {model_caffemodel} -i {dataset} -b {batch} -d {device} -ni {iteration}'
         channel_swap = self._test.dep_parameters.channel_swap
-        if channel_swap:
-            common_params = IntelCaffeProcess._add_argument_to_cmd_line(common_params, '--channel_swap', channel_swap)
+        common_params = IntelCaffeProcess._add_optional_argument_to_cmd_line(common_params, '--channel_swap', channel_swap)
         mean = self._test.dep_parameters.mean
-        if mean:
-            common_params = IntelCaffeProcess._add_argument_to_cmd_line(common_params, '--mean', mean)
+        common_params = IntelCaffeProcess._add_optional_argument_to_cmd_line(common_params, '--mean', mean)
         input_scale = self._test.dep_parameters.input_scale
-        if input_scale:
-            common_params = IntelCaffeProcess._add_argument_to_cmd_line(common_params, '--input_scale', input_scale)
+        common_params = IntelCaffeProcess._add_optional_argument_to_cmd_line(common_params, '--input_scale', input_scale)
 
         common_params = IntelCaffeProcess._add_argument_to_cmd_line(common_params, '--raw_output', 'true')
         command_line = f'{python} {path_to_intelcaffe_script} {common_params}'

--- a/src/benchmark/frameworks/intel_caffe/intel_caffe_process.py
+++ b/src/benchmark/frameworks/intel_caffe/intel_caffe_process.py
@@ -35,11 +35,13 @@ class IntelCaffeProcess(ProcessHandler):
 
         common_params = f'-m {model_prototxt} -w {model_caffemodel} -i {dataset} -b {batch} -d {device} -ni {iteration}'
         channel_swap = self._test.dep_parameters.channel_swap
-        common_params = IntelCaffeProcess._add_optional_argument_to_cmd_line(common_params, '--channel_swap', channel_swap)
+        common_params = IntelCaffeProcess._add_optional_argument_to_cmd_line(common_params, '--channel_swap',
+                                                                             channel_swap)
         mean = self._test.dep_parameters.mean
         common_params = IntelCaffeProcess._add_optional_argument_to_cmd_line(common_params, '--mean', mean)
         input_scale = self._test.dep_parameters.input_scale
-        common_params = IntelCaffeProcess._add_optional_argument_to_cmd_line(common_params, '--input_scale', input_scale)
+        common_params = IntelCaffeProcess._add_optional_argument_to_cmd_line(common_params, '--input_scale',
+                                                                             input_scale)
 
         common_params = IntelCaffeProcess._add_argument_to_cmd_line(common_params, '--raw_output', 'true')
         command_line = f'{python} {path_to_intelcaffe_script} {common_params}'

--- a/src/benchmark/frameworks/onnx_runtime/onnx_runtime_parameters_parser.py
+++ b/src/benchmark/frameworks/onnx_runtime/onnx_runtime_parameters_parser.py
@@ -6,10 +6,10 @@ class OnnxRuntimeParametersParser(DependentParametersParser):
     def parse_parameters(self, curr_test):
         dep_parameters_tag = curr_test.getElementsByTagName('FrameworkDependent')[0]
 
-        _shape = dep_parameters_tag.getElementsByTagName('Shape')[0].firstChild
+        _shape = dep_parameters_tag.getElementsByTagName('InputShape')[0].firstChild
         _layout = dep_parameters_tag.getElementsByTagName('Layout')[0].firstChild
         _mean = dep_parameters_tag.getElementsByTagName('Mean')[0].firstChild
-        _scale = dep_parameters_tag.getElementsByTagName('Scale')[0].firstChild
+        _scale = dep_parameters_tag.getElementsByTagName('InputScale')[0].firstChild
         _thread_count = dep_parameters_tag.getElementsByTagName('ThreadCount')[0].firstChild
         _inference_requests_count = dep_parameters_tag.getElementsByTagName('InferenceRequestsCount')[0].firstChild
 

--- a/src/benchmark/frameworks/openvino/openvino_benchmark_process.py
+++ b/src/benchmark/frameworks/openvino/openvino_benchmark_process.py
@@ -79,10 +79,47 @@ class OpenVINOBenchmarkPythonProcess(OpenVINOBenchmarkProcess):
             arguments = self._add_extension_for_cmd_line(arguments, extension, device)
 
         nthreads = self._test.dep_parameters.nthreads
-        if nthreads:
-            arguments = self._add_argument_to_cmd_line(arguments, '-nthreads', nthreads)
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-nthreads', nthreads)
 
         arguments = self._add_perf_hint_for_cmd_line(arguments, self._perf_hint)
+
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-shape', self._test.dep_parameters.shape)
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-layout', self._test.dep_parameters.layout)
+
+        command_line = f'benchmark_app {arguments}'
+        return command_line
+
+
+class OpenVINOBenchmarkPythonOnnxProcess(OpenVINOBenchmarkPythonProcess):
+    def __init__(self, test, executor, log):
+        super().__init__(test, executor, log, 'none')
+
+    @staticmethod
+    def create_process(test, executor, log):
+        return OpenVINOBenchmarkPythonOnnxProcess(test, executor, log)
+
+    def _fill_command_line(self):
+        model_xml = self._test.model.model
+        dataset = self._test.dataset.path
+        batch = self._test.indep_parameters.batch_size
+        device = self._test.indep_parameters.device
+        iteration = self._test.indep_parameters.iteration
+
+        arguments = (f'-m {model_xml} -i {dataset} -b {batch} -d {device} -niter {iteration} '
+                     f'-hint none -api sync ')
+
+        extension = self._test.dep_parameters.extension
+        if extension:
+            arguments = self._add_extension_for_cmd_line(arguments, extension, device)
+
+        nthreads = self._test.dep_parameters.nthreads
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-nthreads', nthreads)
+
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-shape', self._test.dep_parameters.shape)
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-layout', self._test.dep_parameters.layout)
+
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-imean', self._test.dep_parameters.mean)
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-iscale', self._test.dep_parameters.input_scale)
 
         command_line = f'benchmark_app {arguments}'
         return command_line
@@ -123,10 +160,12 @@ class OpenVINOBenchmarkCppProcess(OpenVINOBenchmarkProcess):
             arguments = self._add_extension_for_cmd_line(arguments, extension, device)
 
         nthreads = self._test.dep_parameters.nthreads
-        if nthreads:
-            arguments = self._add_argument_to_cmd_line(arguments, '-nthreads', nthreads)
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-nthreads', nthreads)
 
         arguments = self._add_perf_hint_for_cmd_line(arguments, self._perf_hint)
+
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-shape', self._test.dep_parameters.shape)
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-layout', self._test.dep_parameters.layout)
 
         command_line = f'{self._benchmark_path} {arguments}'
         return command_line
@@ -148,3 +187,39 @@ class OpenVINOBenchmarkCppProcess(OpenVINOBenchmarkProcess):
         latency = round(float(report['execution_results']['latency_median']) / MILLISECONDS_IN_SECOND, 3)
 
         return average_time_of_single_pass, fps, latency
+
+
+class OpenVINOBenchmarkCppOnnxProcess(OpenVINOBenchmarkCppProcess):
+    def __init__(self, test, executor, log, cpp_benchmarks_dir):
+        super().__init__(test, executor, log, cpp_benchmarks_dir, 'none')
+
+    @staticmethod
+    def create_process(test, executor, log, cpp_benchmarks_dir=None):
+        return OpenVINOBenchmarkCppOnnxProcess(test, executor, log, cpp_benchmarks_dir)
+
+    def _fill_command_line(self):
+        model_xml = self._test.model.model
+        dataset = self._test.dataset.path
+        batch = self._test.indep_parameters.batch_size
+        device = self._test.indep_parameters.device
+        iteration = self._test.indep_parameters.iteration
+
+        arguments = (f'-m {model_xml} -i {dataset} -b {batch} -d {device} -niter {iteration} '
+                     f'-hint none -api sync -report_type "no_counters" '
+                     f'-json_stats -report_folder {self._report_path.parent.absolute()}')
+
+        extension = self._test.dep_parameters.extension
+        if extension:
+            arguments = self._add_extension_for_cmd_line(arguments, extension, device)
+
+        nthreads = self._test.dep_parameters.nthreads
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-nthreads', nthreads)
+
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-shape', self._test.dep_parameters.shape)
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-layout', self._test.dep_parameters.layout)
+
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-imean', self._test.dep_parameters.mean)
+        arguments = self._add_optional_argument_to_cmd_line(arguments, '-iscale', self._test.dep_parameters.input_scale)
+
+        command_line = f'{self._benchmark_path} {arguments}'
+        return command_line

--- a/src/benchmark/frameworks/openvino/openvino_parameters_parser.py
+++ b/src/benchmark/frameworks/openvino/openvino_parameters_parser.py
@@ -12,6 +12,10 @@ class OpenVINOParametersParser(DependentParametersParser):
         CONFIG_FRAMEWORK_DEPENDENT_ASYNC_REQUEST_COUNT_TAG = 'AsyncRequestCount'
         CONFIG_FRAMEWORK_DEPENDENT_THREAD_COUNT_TAG = 'ThreadCount'
         CONFIG_FRAMEWORK_DEPENDENT_STREAM_COUNT_TAG = 'StreamCount'
+        CONFIG_FRAMEWORK_DEPENDENT_SHAPE_TAG = 'InputShape'
+        CONFIG_FRAMEWORK_DEPENDENT_LAYOUT_TAG = 'Layout'
+        CONFIG_FRAMEWORK_DEPENDENT_MEAN_TAG = 'Mean'
+        CONFIG_FRAMEWORK_DEPENDENT_SCALE_TAG = 'InputScale'
 
         dep_parameters_tag = curr_test.getElementsByTagName(CONFIG_FRAMEWORK_DEPENDENT_TAG)[0]
 
@@ -26,22 +30,41 @@ class OpenVINOParametersParser(DependentParametersParser):
         _stream_count = dep_parameters_tag.getElementsByTagName(
             CONFIG_FRAMEWORK_DEPENDENT_STREAM_COUNT_TAG)[0].firstChild
 
+        _shape, _layout, _mean, _input_scale = None, None, None, None
+        if (dep_parameters_tag.getElementsByTagName(CONFIG_FRAMEWORK_DEPENDENT_SHAPE_TAG)):
+            _shape = dep_parameters_tag.getElementsByTagName(CONFIG_FRAMEWORK_DEPENDENT_SHAPE_TAG)[0].firstChild
+        if (dep_parameters_tag.getElementsByTagName(CONFIG_FRAMEWORK_DEPENDENT_LAYOUT_TAG)):
+            _layout = dep_parameters_tag.getElementsByTagName(CONFIG_FRAMEWORK_DEPENDENT_LAYOUT_TAG)[0].firstChild
+        if (dep_parameters_tag.getElementsByTagName(CONFIG_FRAMEWORK_DEPENDENT_MEAN_TAG)):
+            _mean = dep_parameters_tag.getElementsByTagName(CONFIG_FRAMEWORK_DEPENDENT_MEAN_TAG)[0].firstChild
+        if (dep_parameters_tag.getElementsByTagName(CONFIG_FRAMEWORK_DEPENDENT_SCALE_TAG)):
+            _input_scale = dep_parameters_tag.getElementsByTagName(CONFIG_FRAMEWORK_DEPENDENT_SCALE_TAG)[0].firstChild
+
         return OpenVINOParameters(
             mode=_mode.data if _mode else None,
             extension=_extension.data if _extension else None,
             async_request_count=_async_request_count.data if _async_request_count else None,
             thread_count=_thread_count.data if _thread_count else None,
             stream_count=_stream_count.data if _stream_count else None,
+            shape=_shape.data if _shape else None,
+            layout=_layout.data if _layout else None,
+            mean=_mean.data if _mean else None,
+            input_scale=_input_scale.data if _input_scale else None,
         )
 
 
 class OpenVINOParameters(FrameworkParameters):
-    def __init__(self, mode, extension, async_request_count, thread_count, stream_count):
+    def __init__(self, mode, extension, async_request_count, thread_count, stream_count, shape, layout, mean,
+                 input_scale):
         self.mode = None
         self.extension = None
         self.async_request = None
         self.nthreads = None
         self.nstreams = None
+        self.shape = None
+        self.layout = None
+        self.mean = None
+        self.input_scale = None
 
         if self._mode_is_correct(mode):
             self.mode = mode.title()
@@ -67,10 +90,26 @@ class OpenVINOParameters(FrameworkParameters):
                 else:
                     raise ValueError('Stream count can only take values: integer greater than zero.')
 
+        if 'ovbenchmark' in self.mode.lower():
+            if self._parameter_not_is_none(shape):
+                self.shape = shape.strip()
+            if self._parameter_not_is_none(layout):
+                self.layout = layout.strip()
+
+        if 'onnx' in self.mode.lower():
+            if self._parameter_not_is_none(mean):
+                if self._mean_is_correct(mean):
+                    self.mean = mean.strip()
+                else:
+                    raise ValueError('Mean can only take values: list of 3 float elements.')
+            if self._parameter_not_is_none(input_scale):
+                self.input_scale = input_scale.strip()
+
     @staticmethod
     def _mode_is_correct(mode):
-        const_correct_mode = ['sync', 'async', 'ovbenchmark_python_latency', 'ovbenchmark_python_throughput',
-                              'ovbenchmark_cpp_latency', 'ovbenchmark_cpp_throughput']
+        const_correct_mode = ['sync', 'async',
+                              'ovbenchmark_python_latency', 'ovbenchmark_python_throughput', 'ovbenchmark_python_onnx',
+                              'ovbenchmark_cpp_latency', 'ovbenchmark_cpp_throughput', 'ovbenchmark_cpp_onnx']
         if mode.lower() in const_correct_mode:
             return True
         raise ValueError(f'Mode is a required parameter. Mode can only take values: {", ".join(const_correct_mode)}')

--- a/src/benchmark/frameworks/openvino/openvino_process_factory.py
+++ b/src/benchmark/frameworks/openvino/openvino_process_factory.py
@@ -1,4 +1,5 @@
-from .openvino_benchmark_process import OpenVINOBenchmarkPythonProcess, OpenVINOBenchmarkCppProcess
+from .openvino_benchmark_process import (OpenVINOBenchmarkPythonProcess, OpenVINOBenchmarkCppProcess,
+                                         OpenVINOBenchmarkPythonOnnxProcess, OpenVINOBenchmarkCppOnnxProcess)
 from .openvino_python_api_process import AsyncOpenVINOProcess, SyncOpenVINOProcess
 
 
@@ -12,8 +13,12 @@ def create_process(test, executor, log, cpp_benchmarks_dir=None):
         return OpenVINOBenchmarkPythonProcess(test, executor, log, 'latency')
     if mode == 'ovbenchmark_python_throughput':
         return OpenVINOBenchmarkPythonProcess(test, executor, log, 'throughput')
+    if mode == 'ovbenchmark_python_onnx':
+        return OpenVINOBenchmarkPythonOnnxProcess(test, executor, log)
     if mode == 'ovbenchmark_cpp_latency':
         return OpenVINOBenchmarkCppProcess(test, executor, log, cpp_benchmarks_dir, 'latency')
     if mode == 'ovbenchmark_cpp_throughput':
         return OpenVINOBenchmarkCppProcess(test, executor, log, cpp_benchmarks_dir, 'throughput')
+    if mode == 'ovbenchmark_cpp_onnx':
+        return OpenVINOBenchmarkCppOnnxProcess(test, executor, log, cpp_benchmarks_dir)
     raise AssertionError(f'Unknown openvino running mode {mode}')

--- a/src/benchmark/frameworks/openvino/openvino_test.py
+++ b/src/benchmark/frameworks/openvino/openvino_test.py
@@ -14,6 +14,9 @@ class OpenVINOTest(Test):
         parameters.update({'Iteration count': self.indep_parameters.iteration})
         parameters.update({'Thread count': self.dep_parameters.nthreads})
         parameters.update({'Stream count': self.dep_parameters.nstreams})
+        parameters.update({'Mean': self.dep_parameters.mean})
+        parameters.update({'Scale': self.dep_parameters.input_scale})
+        parameters.update({'Shape': self.dep_parameters.shape})
         other_param = self._get_optional_parameters_string(parameters)
 
         report_res = {

--- a/src/benchmark/frameworks/tensorflow/tensorflow_parameters_parser.py
+++ b/src/benchmark/frameworks/tensorflow/tensorflow_parameters_parser.py
@@ -109,20 +109,6 @@ class TensorFlowParameters(FrameworkParameters):
         if self._parameter_not_is_none(kmp_affinity):
             self.kmp_affinity = kmp_affinity
 
-    def _channel_swap_is_correct(channel_swap):
-        set_check = {'0', '1', '2'}
-        set_in = set(channel_swap.split())
-        return set_in == set_check
-
-    def _mean_is_correct(self, mean):
-        mean_check = mean.split()
-        if len(mean_check) != 3:
-            return False
-        for i in mean_check:
-            if not self._float_value_is_correct(i):
-                return False
-        return True
-
     def _input_shape_is_correct(self, input_shape):
         shape_check = input_shape.split()
         if len(shape_check) != 3:

--- a/src/benchmark/frameworks/tensorflow/tensorflow_process.py
+++ b/src/benchmark/frameworks/tensorflow/tensorflow_process.py
@@ -35,29 +35,21 @@ class TensorFlowProcess(ProcessHandler):
         common_params = f'-m {model} -i {dataset} -b {batch} -d {device} -ni {iteration}'
 
         channel_swap = self._test.dep_parameters.channel_swap
-        if channel_swap:
-            common_params = self._add_argument_to_cmd_line(common_params, '--channel_swap', channel_swap)
+        common_params = self._add_optional_argument_to_cmd_line(common_params, '--channel_swap', channel_swap)
         mean = self._test.dep_parameters.mean
-        if mean:
-            common_params = self._add_argument_to_cmd_line(common_params, '--mean', mean)
+        common_params = self._add_optional_argument_to_cmd_line(common_params, '--mean', mean)
         input_scale = self._test.dep_parameters.input_scale
-        if input_scale:
-            common_params = self._add_argument_to_cmd_line(common_params, '--input_scale', input_scale)
+        common_params = self._add_optional_argument_to_cmd_line(common_params, '--input_scale', input_scale)
         input_shape = self._test.dep_parameters.input_shape
-        if input_shape:
-            common_params = self._add_argument_to_cmd_line(common_params, '--input_shape', input_shape)
+        common_params = self._add_optional_argument_to_cmd_line(common_params, '--input_shape', input_shape)
         input_name = self._test.dep_parameters.input_name
-        if input_name:
-            common_params = self._add_argument_to_cmd_line(common_params, '--input_name', input_name)
+        common_params = self._add_optional_argument_to_cmd_line(common_params, '--input_name', input_name)
         output_names = self._test.dep_parameters.output_names
-        if output_names:
-            common_params = self._add_argument_to_cmd_line(common_params, '--output_names', output_names)
+        common_params = self._add_optional_argument_to_cmd_line(common_params, '--output_names', output_names)
         num_inter_threads = self._test.dep_parameters.num_inter_threads
-        if num_inter_threads:
-            common_params = self._add_argument_to_cmd_line(common_params, '--num_inter_threads', num_inter_threads)
+        common_params = self._add_optional_argument_to_cmd_line(common_params, '--num_inter_threads', num_inter_threads)
         num_intra_threads = self._test.dep_parameters.num_intra_threads
-        if num_intra_threads:
-            common_params = self._add_argument_to_cmd_line(common_params, '--num_intra_threads', num_intra_threads)
+        common_params = self._add_optional_argument_to_cmd_line(common_params, '--num_intra_threads', num_intra_threads)
 
         common_params = self._add_argument_to_cmd_line(common_params, '--raw_output', 'true')
 

--- a/src/benchmark/tests/test_processes.py
+++ b/src/benchmark/tests/test_processes.py
@@ -7,7 +7,9 @@ from src.benchmark.frameworks.framework_wrapper_registry import FrameworkWrapper
 from src.benchmark.frameworks.intel_caffe.intel_caffe_process import IntelCaffeProcess
 from src.benchmark.frameworks.known_frameworks import KnownFrameworks
 from src.benchmark.frameworks.openvino.openvino_benchmark_process import (OpenVINOBenchmarkPythonProcess,
-                                                                          OpenVINOBenchmarkCppProcess)
+                                                                          OpenVINOBenchmarkCppProcess,
+                                                                          OpenVINOBenchmarkPythonOnnxProcess,
+                                                                          OpenVINOBenchmarkCppOnnxProcess)
 from src.benchmark.frameworks.openvino.openvino_process import OpenVINOProcess
 from src.benchmark.frameworks.openvino.openvino_python_api_process import AsyncOpenVINOProcess, SyncOpenVINOProcess
 from src.benchmark.frameworks.processes import ProcessHandler
@@ -62,7 +64,9 @@ def test_python_version(os, mocker):
                                   ['ovbenchmark_python_latency', OpenVINOBenchmarkPythonProcess],
                                   ['ovbenchmark_python_throughput', OpenVINOBenchmarkPythonProcess],
                                   ['ovbenchmark_cpp_latency', OpenVINOBenchmarkCppProcess],
-                                  ['ovbenchmark_cpp_throughput', OpenVINOBenchmarkCppProcess]])
+                                  ['ovbenchmark_cpp_throughput', OpenVINOBenchmarkCppProcess],
+                                  ['ovbenchmark_cpp_onnx', OpenVINOBenchmarkCppOnnxProcess],
+                                  ['ovbenchmark_python_onnx', OpenVINOBenchmarkPythonOnnxProcess]])
 def test_framework_wrapper(inference_framework, mode, mocker):
     test = TEST_BASIC_LINE
     test.indep_parameters.inference_framework = inference_framework[0]

--- a/src/configs/README.md
+++ b/src/configs/README.md
@@ -69,6 +69,12 @@
     физическому количеству ядер в системе.
   - `StreamCount` - опциональный тег. Может быть заполнен для асинхронного интерфейса.
     Описывает максимальное количество одновременно выполняющихся запросов на вывод.
+  - `InputShape` - тег, необязательный для заполнения; может отсуствовать. Определяет размеры входного тензора. По умолчанию не установлен.
+  - `Layout`- тег, необязательный для заполнения; может отсуствовать. Определяет формат входного тензора. По умолчанию не установлен.
+  - `Mean` - тег, необязательный для заполнения; может отсуствовать. Определяет средние значения, которые будут вычитаться
+    по каждому из каналов входного изображения.
+  - `InputScale`- тег, необязательный для заполнения; может отсуствовать. Определяет коэффициент масштабирования входного
+    изображения.
 
 - Набор тегов для тестирования вывода средствами Intel Optimization for Caffe:
 
@@ -110,6 +116,21 @@
   - `KmpAffinity` - опциональный тег. Позволяет установить значение переменной
     окружения KMP_AFFINITY. По умолчанию не задан. Подробнее про атрибуты, принимаемые
     переменной окружения, [здесь][kmp-affinity-docs].
+
+- Набор тегов для тестирования вывода средствами ONNX Runtime:
+
+  - `InputShape` - тег, необязательный для заполнения. Определяет размеры входного тензора. По умолчанию не установлен.
+  - `Layout` - тег, необязательный для заполнения. Определяет формат входного тензора. По умолчанию не установлен и 
+    выбирается ONNX Runtime автоматически.
+  - `Mean` - тег, необязательный для заполнения. Определяет средние значения, которые будут вычитаться
+    по каждому из каналов входного изображения.
+  - `InputScale`- тег, необязательный для заполнения. Определяет коэффициент масштабирования входного
+    изображения.
+  - `ThreadCount` -тег, необязательный для заполнения.  Описывает максимальное количество физических
+    потоков для выполнения вывода. По умолчанию будет выставлено число потоков, равное
+    физическому количеству ядер в системе.
+  - `InferenceRequestsCount` - тег, необязательный для заполнения. Определяет число запросов на вывод. По умолчанию
+    не установлен и выбирается ONNX Runtime автоматически.
 
 
 ### Примеры заполнения
@@ -252,6 +273,43 @@
             <KmpAffinity>balanced,verbose,granularity=core</KmpAffinity>
         </FrameworkDependent>
     </Test>
+</Tests>
+```
+
+#### Пример заполнения конфигурации для измерения производительности вывода средствами ONNX Runtime
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<Tests>
+  <Test>
+    <Model>
+      <Task>classification</Task>
+      <Name>resnet-50-pytorch</Name>
+      <Precision>FP32</Precision>
+      <SourceFramework>pytorch</SourceFramework>
+      <ModelPath>public/resnet-50-pytorch/resnet-v1-50.onnx</ModelPath>
+      <WeightsPath>None</WeightsPath>
+    </Model>
+    <Dataset>
+      <Name>ImageNet</Name>
+      <Path>/mnt/datasets/ILSVRC2012_img_val</Path>
+    </Dataset>
+    <FrameworkIndependent>
+      <InferenceFramework>ONNX Runtime</InferenceFramework>
+      <BatchSize>1</BatchSize>
+      <Device>CPU</Device>
+      <IterationCount>100</IterationCount>
+      <TestTimeLimit>60</TestTimeLimit>
+    </FrameworkIndependent>
+    <FrameworkDependent>
+      <Shape></Shape>
+      <Layout></Layout>
+      <Mean>[123.675,116.28,103.53]</Mean>
+      <InputScale>[58.395,57.12,57.375]</InputScale>
+      <ThreadCount></ThreadCount>
+      <InferenceRequestsCount></InferenceRequestsCount>
+    </FrameworkDependent>
+  </Test>
 </Tests>
 ```
 

--- a/src/configs/benchmark_configuration_file_template.xml
+++ b/src/configs/benchmark_configuration_file_template.xml
@@ -26,6 +26,11 @@
             <AsyncRequestCount></AsyncRequestCount>
             <ThreadCount></ThreadCount>
             <StreamCount></StreamCount>
+            <!-- Следующие параметры могут отсутствовать -->
+            <InputShape></InputShape>
+            <Layout></Layout>
+            <Mean></Mean>
+            <InputScale></InputScale>
         </FrameworkDependent>
     </Test>
     <Test>
@@ -110,10 +115,10 @@
             <TestTimeLimit></TestTimeLimit> 
         </FrameworkIndependent>
         <FrameworkDependent>
-            <Shape></Shape>
+            <InputShape></InputShape>
             <Layout></Layout>
             <Mean></Mean>
-            <Scale></Scale>
+            <InputScale></InputScale>
             <ThreadCount></ThreadCount>
             <InferenceRequestsCount></InferenceRequestsCount>
         </FrameworkDependent>


### PR DESCRIPTION
- add 2 new modes - ovbenchmark_python_onnx and ovbenchmark_cpp_onnx
- update docs
- add shape & layout for all ovbenchmark* modes
- add mean & scale for ovbenchmark*onnx modes


2 examples with new modes + gpt-2 is working now
[results_gpt2.csv](https://github.com/zmaslova/dl-benchmark/files/9980128/results_gpt2.csv)
[results_resnet.csv](https://github.com/zmaslova/dl-benchmark/files/9980129/results_resnet.csv)
