### PR TITLE
Minimize benchmark third-party dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ wmi; sys_platform == 'win32'
 opencv-python
 PyQt5
 pandas
-psutil
 xlsxwriter
 iteration_utilities

--- a/src/benchmark/executors.py
+++ b/src/benchmark/executors.py
@@ -3,7 +3,6 @@ import os
 import sys
 from pathlib import Path
 
-import docker
 
 sys.path.append(str(Path(__file__).resolve().parents[1].joinpath('utils')))
 from cmd_handler import CMDHandler  # noqa: E402, PLC0411
@@ -84,6 +83,7 @@ class HostExecutor(Executor):
 class DockerExecutor(Executor):
     def __init__(self, log):
         super().__init__(log)
+        import docker
         client = docker.from_env()
         self.container_dict = {cont.name: cont for cont in client.containers.list()}
 

--- a/src/utils/cmd_handler.py
+++ b/src/utils/cmd_handler.py
@@ -1,8 +1,9 @@
 import abc
+import os
+import signal
 import subprocess
 import threading
 import sys
-import psutil
 
 
 class CMDHandler(metaclass=abc.ABCMeta):
@@ -55,9 +56,9 @@ class CMDHandler(metaclass=abc.ABCMeta):
 
     def kill_process_by_pid(self, pid):
         try:
-            process = psutil.Process(pid)
-            for proc in process.children(recursive=True):
-                proc.kill()
-            process.kill()
+            if sys.platform == 'win32':
+                subprocess.call(['taskkill', '/F', '/T', '/PID', str(pid)])
+            else:
+                os.killpg(pid, signal.SIGKILL)
         except OSError as err:
             print(err)

--- a/src/utils/cmd_handler.py
+++ b/src/utils/cmd_handler.py
@@ -1,6 +1,5 @@
 import abc
 import os
-import signal
 import subprocess
 import threading
 import sys
@@ -59,6 +58,6 @@ class CMDHandler(metaclass=abc.ABCMeta):
             if sys.platform == 'win32':
                 subprocess.call(['taskkill', '/F', '/T', '/PID', str(pid)])
             else:
-                os.killpg(pid, signal.SIGKILL)
+                os.system(f'pkill -TERM -P {pid}')
         except OSError as err:
             print(err)


### PR DESCRIPTION
To run benchmark in virtual environments with limited set of installed packages

* Import docker only in case of the corresponding executor selected
* Drop psutil from requirements